### PR TITLE
Fixes for cases where the neighboring lists are relatives

### DIFF
--- a/plugins/list/plugin.js
+++ b/plugins/list/plugin.js
@@ -1090,12 +1090,15 @@
 								// if we have two neighboring lists, merge the list items from the second
 								// into the first, rather than moving one item at a time.
 								var startItem = nextLine.startContainer;
+								var commonAncestor = li.getCommonAncestor(startItem);
 								if (
 									startItem.type == CKEDITOR.NODE_ELEMENT &&
 									startItem.getName() == 'li' &&
 									startItem.getParent().getName() in listNodeNames &&
-									!li.getParent().contains(startItem)
+									!( commonAncestor.getName() in listNodeNames ) &&
+									!( li.contains( startItem ) )
 								) {
+									editor.fire( 'saveSnapshot' );
 									var oldParent = startItem.getParent(),
 										oldRange = nextLine.clone();
 									mergeChildren( oldParent, li.getParent() );
@@ -1104,6 +1107,7 @@
 									oldRange.moveToPosition( oldParent.getParent(), CKEDITOR.POSITION_AFTER_START );
 									oldParent.remove();
 									oldRange.removeEmptyBlocksAtEnd( true );
+									editor.fire( 'saveSnapshot' );
 								} else {
 									joinNextLineToCursor( editor, cursor, nextLine );
 								}

--- a/tests/plugins/list/backspace.html
+++ b/tests/plugins/list/backspace.html
@@ -887,8 +887,8 @@
 		<li>hello
 			<ul>
 				<li>^goodbye</li>
-				<li>cya</li>
 			</ul>
 		</li>
+		<li>cya</li>
 	</ul>
 </textarea>

--- a/tests/plugins/list/backspace.html
+++ b/tests/plugins/list/backspace.html
@@ -874,21 +874,50 @@
 
 <textarea id="delete_into_nested_list1">
 	<ul>
-		<li>hello
+		<li>a
 			<ul>
 				<li>^</li>
 			</ul>
 		</li>
-		<li>goodbye</li>
-		<li>cya</li>
+		<li>b</li>
+		<li>c</li>
 	</ul>
 	=>
 	<ul>
-		<li>hello
+		<li>a
 			<ul>
-				<li>^goodbye</li>
+				<li>^b</li>
 			</ul>
 		</li>
-		<li>cya</li>
+		<li>c</li>
+	</ul>
+</textarea>
+
+<textarea id="delete_into_nested_list2">
+	<ul>
+		<li>a
+			<ul>
+				<li>^</li>
+			</ul>
+		</li>
+		<li>b
+			<ol>
+				<li>c</li>
+			</ol>
+		</li>
+		<li>d</li>
+	</ul>
+	=>
+	<ul>
+		<li>a
+			<ul>
+				<li>^b
+					<ol>
+						<li>c</li>
+					</ol>
+				</li>
+			</ul>
+		</li>
+		<li>d</li>
 	</ul>
 </textarea>

--- a/tests/plugins/list/backspace.html
+++ b/tests/plugins/list/backspace.html
@@ -871,3 +871,24 @@
 		<li>3</li>
 	</ul>
 </textarea>
+
+<textarea id="delete_into_nested_list1">
+	<ul>
+		<li>hello
+			<ul>
+				<li>^</li>
+			</ul>
+		</li>
+		<li>goodbye</li>
+		<li>cya</li>
+	</ul>
+	=>
+	<ul>
+		<li>hello
+			<ul>
+				<li>^goodbye</li>
+				<li>cya</li>
+			</ul>
+		</li>
+	</ul>
+</textarea>

--- a/tests/plugins/list/backspace.js
+++ b/tests/plugins/list/backspace.js
@@ -117,7 +117,9 @@ addTests( 'test delete neighboring ol and ul lists', 'delete_neighboring_lists1'
 addTests( 'test delete neighboring ul and ol lists', 'delete_neighboring_lists2', DEL );
 addTests( 'test delete neighboring ul and ol lists that are already nested inside another list', 'delete_neighboring_lists3', DEL );
 addTests( 'test delete nested neighboring lists', 'delete_neighboring_nested_lists1', DEL );
+// prevent blowing up cases where the neighboring lists are in the same tree
 addTests( 'test delete into nested list', 'delete_into_nested_list1', DEL);
+addTests( 'test delete into nested list', 'delete_into_nested_list2', DEL);
 
 // word-like backspace behaviour
 addTests( 'test backspace neighboring ol and ul lists', 'backspace_neighboring_lists1', BACKSPACE );

--- a/tests/plugins/list/backspace.js
+++ b/tests/plugins/list/backspace.js
@@ -118,8 +118,8 @@ addTests( 'test delete neighboring ul and ol lists', 'delete_neighboring_lists2'
 addTests( 'test delete neighboring ul and ol lists that are already nested inside another list', 'delete_neighboring_lists3', DEL );
 addTests( 'test delete nested neighboring lists', 'delete_neighboring_nested_lists1', DEL );
 // prevent blowing up cases where the neighboring lists are in the same tree
-addTests( 'test delete into nested list', 'delete_into_nested_list1', DEL);
-addTests( 'test delete into nested list', 'delete_into_nested_list2', DEL);
+addTests( 'test delete list parent sibling into nested list', 'delete_into_nested_list1', DEL);
+addTests( 'test delete list parent sibling and child into nested list', 'delete_into_nested_list2', DEL);
 
 // word-like backspace behaviour
 addTests( 'test backspace neighboring ol and ul lists', 'backspace_neighboring_lists1', BACKSPACE );

--- a/tests/plugins/list/backspace.js
+++ b/tests/plugins/list/backspace.js
@@ -117,6 +117,7 @@ addTests( 'test delete neighboring ol and ul lists', 'delete_neighboring_lists1'
 addTests( 'test delete neighboring ul and ol lists', 'delete_neighboring_lists2', DEL );
 addTests( 'test delete neighboring ul and ol lists that are already nested inside another list', 'delete_neighboring_lists3', DEL );
 addTests( 'test delete nested neighboring lists', 'delete_neighboring_nested_lists1', DEL );
+addTests( 'test delete into nested list', 'delete_into_nested_list1', DEL);
 
 // word-like backspace behaviour
 addTests( 'test backspace neighboring ol and ul lists', 'backspace_neighboring_lists1', BACKSPACE );


### PR DESCRIPTION
The previous change only made sense when two lists were beside each other.

In cases where you have say, a nested list beside another nested list, or just a nested list with siblings of the parent "beside" it, content destruction would occur.  
