### PR TITLE
Add a setting to not un-show blocks when unfocusing the editor

### DIFF
--- a/plugins/showblocks/plugin.js
+++ b/plugins/showblocks/plugin.js
@@ -144,6 +144,15 @@
 } )();
 
 /**
+ * Whether to continue showing the blocks on blur (inline only)
+ *
+ *		config.showBlocksOnBlur = false;
+ *
+ * @cfg {Boolean} [showBlocksOnBlur=false]
+ * @member CKEDITOR.config
+ */
+
+/**
  * Whether to automaticaly enable the show block" command when the editor loads.
  *
  *		config.startupOutlineBlocks = true;

--- a/plugins/showblocks/plugin.js
+++ b/plugins/showblocks/plugin.js
@@ -23,9 +23,13 @@
 		},
 
 		refresh: function( editor ) {
+			var showBlocksOnBlur = editor.config.showBlocksOnBlur || false;
 			if ( editor.document ) {
 				// Show blocks turns inactive after editor loses focus when in inline.
-				var showBlocks = ( this.state == CKEDITOR.TRISTATE_ON && ( editor.elementMode != CKEDITOR.ELEMENT_MODE_INLINE || editor.focusManager.hasFocus ) );
+				var showBlocks = (
+					this.state == CKEDITOR.TRISTATE_ON &&
+					( editor.elementMode != CKEDITOR.ELEMENT_MODE_INLINE || showBlocksOnBlur || editor.focusManager.hasFocus )
+				);
 
 				var funcName = showBlocks ? 'attachClass' : 'removeClass';
 				editor.editable()[ funcName ]( 'cke_show_blocks' );

--- a/tests/plugins/showblocks/showblocksonblur.js
+++ b/tests/plugins/showblocks/showblocksonblur.js
@@ -1,0 +1,56 @@
+/* bender-tags: editor,unit */
+/* bender-ckeditor-plugins: showblocks */
+
+CKEDITOR.focusManager._.blurDelay = 0;
+
+bender.editors = {
+	editor: {
+		creator: 'inline',
+			config: {
+				showBlocksOnBlur: true
+			}
+		},
+	editorShowBlocksFalse: {
+		creator: 'inline',
+		config: {
+			showBlocksOnBlur: false
+		}
+	}
+};
+
+bender.test(
+	{
+		'test config to keep showblocks on blur': function() {
+			var bot = this.editorBots.editor,
+				editor = bot.editor;
+
+			editor.focus();
+
+			assert.isTrue(editor.editable().hasFocus);
+
+			bot.execCommand( 'showblocks' );
+
+			assert.isTrue( editor.editable().hasClass('cke_show_blocks') );
+
+			editor.focusManager.blur( true );
+
+			assert.isTrue( editor.editable().hasClass('cke_show_blocks') );
+		},
+		'test config to not keep showblocks on blur': function() {
+			var bot = this.editorBots.editorShowBlocksFalse,
+				editor = bot.editor;
+
+			editor.focus();
+
+			assert.isTrue(editor.editable().hasFocus);
+
+			bot.execCommand( 'showblocks' );
+
+			assert.isTrue( editor.editable().hasClass('cke_show_blocks') );
+
+			editor.focusManager.blur( true );
+
+			assert.isFalse( editor.editable().hasClass('cke_show_blocks') );
+		}
+	}
+);


### PR DESCRIPTION
In our case, where we show the blocks by default, this causes editor shrinkage + reflow every time you click on anything outside of the editor.  
