### PR TITLE
Fix Firefox/IE list deletion issue with empty inline "styling" tags

### DIFF
--- a/dev/builder/build-config.js
+++ b/dev/builder/build-config.js
@@ -50,7 +50,7 @@ var CKBUILDER_CONFIG = {
 		'tests'
 	],
 	plugins : {
-		'a11yhelp' : 1,
+		'a11yhelp' : 0,
 		'autogrow' : 1,
                 'autolink': 1,
 		'basicstyles' : 1,

--- a/dev/builder/build-config.js
+++ b/dev/builder/build-config.js
@@ -51,7 +51,7 @@ var CKBUILDER_CONFIG = {
 	],
 	plugins : {
 		'a11yhelp' : 0,
-		'autogrow' : 1,
+		'autogrow' : 0,
                 'autolink': 1,
 		'basicstyles' : 1,
 		'blockquote' : 1,

--- a/plugins/list/plugin.js
+++ b/plugins/list/plugin.js
@@ -1097,7 +1097,7 @@
 									startItem.getParent().getName() in listNodeNames &&
 									!( commonAncestor.getName() in listNodeNames ) &&
 									!( li.contains( startItem ) ) &&
-									!( li.equals (startItem ) )
+									!( li.equals ( startItem ) ) // in Firefox/IE, sublists can incorrectly be detected as being separate lists if not for this
 								) {
 									editor.fire( 'saveSnapshot' );
 									var oldParent = startItem.getParent(),

--- a/plugins/list/plugin.js
+++ b/plugins/list/plugin.js
@@ -1096,7 +1096,8 @@
 									startItem.getName() == 'li' &&
 									startItem.getParent().getName() in listNodeNames &&
 									!( commonAncestor.getName() in listNodeNames ) &&
-									!( li.contains( startItem ) )
+									!( li.contains( startItem ) ) &&
+									!( li.equals (startItem ) )
 								) {
 									editor.fire( 'saveSnapshot' );
 									var oldParent = startItem.getParent(),

--- a/tests/plugins/list/backspace.html
+++ b/tests/plugins/list/backspace.html
@@ -921,3 +921,26 @@
 		<li>d</li>
 	</ul>
 </textarea>
+
+<textarea id="delete_into_nested_list3">
+	<ul>
+		<li>a
+			<ul>
+				<li>b</li>
+				<li>^</li>
+			</ul>
+		</li>
+		<li><strong></strong></li>
+		<li>c</li>
+	</ul>
+	=>
+	<ul>
+		<li>a
+			<ul>
+				<li>b</li>
+				<li><strong></strong>^</li>
+			</ul>
+		</li>
+		<li>c</li>
+	</ul>
+</textarea>

--- a/tests/plugins/list/backspace.js
+++ b/tests/plugins/list/backspace.js
@@ -120,6 +120,7 @@ addTests( 'test delete nested neighboring lists', 'delete_neighboring_nested_lis
 // prevent blowing up cases where the neighboring lists are in the same tree
 addTests( 'test delete list parent sibling into nested list', 'delete_into_nested_list1', DEL);
 addTests( 'test delete list parent sibling and child into nested list', 'delete_into_nested_list2', DEL);
+addTests( 'test crash when target has a empty inline tag', 'delete_into_nested_list3', DEL); // due to data filters this test doesn't test 100% of the case
 
 // word-like backspace behaviour
 addTests( 'test backspace neighboring ol and ul lists', 'backspace_neighboring_lists1', BACKSPACE );


### PR DESCRIPTION
Unfortunately, this can't be tested very easily (outside of a lot of manual testing/inspection of HTML.)  Something weird with the order of events firing in browsers, I think.  