### PR TITLE
Fix for reverting nested lists

### DIFF
--- a/plugins/list/plugin.js
+++ b/plugins/list/plugin.js
@@ -552,6 +552,7 @@
 			child.remove();
 
 			refNode ? child[ forward ? 'insertBefore' : 'insertAfter' ]( refNode ) : into.append( child, forward );
+			refNode = child;
 		}
 	}
 

--- a/tests/plugins/list/list.js
+++ b/tests/plugins/list/list.js
@@ -202,5 +202,18 @@ bender.test( {
 		bot.setHtmlWithSelection( '<ul><li><table><tr><td>^foo</td></tr></table></li></ul>' );
 		var bList = ed.getCommand( 'bulletedlist' );
 		assert.areSame( CKEDITOR.TRISTATE_OFF, bList.state, 'check numbered list inactive' );
+	},
+
+	// #2721
+	'test sublist order after removing higher order sublist': function() {
+		var bot = this.editorBots.editor1,
+			editor = bot.editor;
+
+		bot.setHtmlWithSelection( '<ol><li>test<ol><li>^<ol><li>a</li><li>b</li><li>c</li></ol></li></ol></li></ol>' );
+		editor.fire( 'key', {
+			domEvent: new CKEDITOR.dom.event( { keyCode: 8 } )
+		} );
+
+		assert.areSame( '<ol><li>test<ol><li>a</li><li>b</li><li>c</li></ol></li></ol>', bender.tools.compatHtml( editor.getData() ) );
 	}
 } );

--- a/tests/plugins/list/manual/sublistreverse.html
+++ b/tests/plugins/list/manual/sublistreverse.html
@@ -1,0 +1,19 @@
+<textarea id="editor">
+	<ol>
+		<li>test
+		<ol>
+			<li>$
+			<ol>
+				<li>a</li>
+				<li>b</li>
+				<li>c</li>
+			</ol>
+			</li>
+		</ol>
+		</li>
+	</ol>
+</textarea>
+
+<script>
+	CKEDITOR.replace( 'editor' );
+</script>

--- a/tests/plugins/list/manual/sublistreverse.md
+++ b/tests/plugins/list/manual/sublistreverse.md
@@ -1,0 +1,26 @@
+@bender-tags: bug, 2721
+@bender-ui: collapsed
+@bender-ckeditor-plugins: wysiwygarea, toolbar, list,sourcearea, undo, elementspath
+
+1. Place caret in list after dollar symbol (`$`).
+1. Press backspace two times.
+
+## Expected
+
+Sublist is ordered alphabetically:
+```
+1. Test
+	1. a
+	2. b
+	3. c
+```
+
+## Unexpected
+
+Sublist order is reversed:
+```
+1. Test
+	1. c
+	2. b
+	3. a
+```


### PR DESCRIPTION
Cherry-picking fix for nested lists reversal
https://github.com/ckeditor/ckeditor4/commit/3343223a

for https://trello.com/c/ZcjT5dLq/589-unc-nash-editing-lists-switches-the-order-of-list-items-with-no-warning

Also cherry picking tests for this fix.