### PR TITLE
Add img:title into AllowedContent rules

### DIFF
--- a/config.js
+++ b/config.js
@@ -113,7 +113,7 @@ CKEDITOR.editorConfig = function ( config ) {
 			attributes: 'align,longdesc,frameborder,height,name,scrolling,src,title,width'
 		},
 		img: {
-			attributes: 'src,alt,width,height'
+			attributes: 'src,alt,title,width,height'
 		},
 		'address div h1 h2 h3 h4 h5 h6 p pre sub sup em strong': {
 			classes: 'highlight',

--- a/configs/cleaner_config.js
+++ b/configs/cleaner_config.js
@@ -108,7 +108,7 @@ CKEDITOR.editorConfig = function ( config ) {
 			attributes: 'align,longdesc,frameborder,height,name,scrolling,src,title,width'
 		},
 		img: {
-			attributes: 'src,alt,width,height'
+			attributes: 'src,alt,title,width,height'
 		},
 		'address div h1 h2 h3 h4 h5 h6 p pre sub sup em strong': {
 			classes: 'highlight',

--- a/configs/editor_config.js
+++ b/configs/editor_config.js
@@ -108,7 +108,7 @@ CKEDITOR.editorConfig = function ( config ) {
 			attributes: 'align,longdesc,frameborder,height,name,scrolling,src,title,width'
 		},
 		img: {
-			attributes: 'src,alt,width,height'
+			attributes: 'src,alt,title,width,height'
 		},
 		'address div h1 h2 h3 h4 h5 h6 p pre sub sup em strong': {
 			classes: 'highlight',


### PR DESCRIPTION
Add Img:title into AllowedContnet rules to solve this client's request

https://trello.com/c/48LrE84a/662-image-properties-not-appearing-when-inserting-an-attached-image-chrome-alt-text-508-compliance