### PR TITLE
Rollback adding of title into img

### DIFF
--- a/config.js
+++ b/config.js
@@ -113,7 +113,7 @@ CKEDITOR.editorConfig = function ( config ) {
 			attributes: 'align,longdesc,frameborder,height,name,scrolling,src,title,width'
 		},
 		img: {
-			attributes: 'src,alt,title,width,height'
+			attributes: 'src,alt,width,height'
 		},
 		'address div h1 h2 h3 h4 h5 h6 p pre sub sup em strong': {
 			classes: 'highlight',

--- a/configs/cleaner_config.js
+++ b/configs/cleaner_config.js
@@ -108,7 +108,7 @@ CKEDITOR.editorConfig = function ( config ) {
 			attributes: 'align,longdesc,frameborder,height,name,scrolling,src,title,width'
 		},
 		img: {
-			attributes: 'src,alt,title,width,height'
+			attributes: 'src,alt,width,height'
 		},
 		'address div h1 h2 h3 h4 h5 h6 p pre sub sup em strong': {
 			classes: 'highlight',

--- a/configs/editor_config.js
+++ b/configs/editor_config.js
@@ -108,7 +108,7 @@ CKEDITOR.editorConfig = function ( config ) {
 			attributes: 'align,longdesc,frameborder,height,name,scrolling,src,title,width'
 		},
 		img: {
-			attributes: 'src,alt,title,width,height'
+			attributes: 'src,alt,width,height'
 		},
 		'address div h1 h2 h3 h4 h5 h6 p pre sub sup em strong': {
 			classes: 'highlight',


### PR DESCRIPTION
During the analysis of https://trello.com/c/48LrE84a/662-image-properties-not-appearing-when-inserting-an-attached-image-chrome-alt-text-508-compliance we made an incorrect assumption for the fix.

We noticed it during the beta test in PolicyStats repo. However, changes were already made in this repo via https://github.com/PolicyStat/ckeditor-dev/pull/25

We made proper fix via https://github.com/PolicyStat/PolicyStat/pull/5381

So incorrect updates in CKeditor have to be reverted.