### PR TITLE
Add list decimal style into allowed content

### DIFF
--- a/plugins/structuredheadings/plugin.js
+++ b/plugins/structuredheadings/plugin.js
@@ -446,7 +446,7 @@
 				title: "Numbering",
 				toolbar: "styles,8",
 				allowedContent: "h1(*); h2(*); h3(*); h4(*); h5(*); h6(*);" +
-					"ol(list-upper-alpha,list-lower-alpha,list-decimal,list-upper-roman,list-lower-roman)",
+					"ol(list-upper-alpha,list-lower-alpha,list-decimal,list-decimal-point,list-upper-roman,list-lower-roman)",
 
 				panel: {
 					css: [CKEDITOR.skin.getPath( "editor" )].concat( editor.config.contentsCss ),

--- a/styles.js
+++ b/styles.js
@@ -72,6 +72,11 @@ CKEDITOR.stylesSet.add( 'default', [
 		attributes: { 'class': 'list-decimal' }
 	},
 	{
+		name: 'List: 1. 1. 1.',
+		element: 'ol',
+		attributes: { 'class': 'list-decimal-point' }
+	},
+	{
 		name: 'List: a. b. c.',
 		element: 'ol',
 		attributes: { 'class': 'list-lower-alpha' }


### PR DESCRIPTION
Merge https://github.com/PolicyStat/ckeditor-plugin-structured-headings/pull/91/ 
And add list-decimal-point into styles.js

Part of https://trello.com/c/WuwrF8is/8-add-list-style-111 issue