### PR TITLE
Generate new ids for duplicated nested ids

### DIFF
--- a/plugins/autoid/plugin.js
+++ b/plugins/autoid/plugin.js
@@ -8,6 +8,7 @@
     ID_ADDED: 'idAdded',
     ID_RETAINED: 'idRetained'
   };
+  var hTags = new Set(["h1", "h2", "h3", "h4", "h5", "h6"]);
 
   CKEDITOR.plugins.add('autoid', {
     init: function (editor) {
@@ -128,6 +129,18 @@
         return element.is('h1', 'h2', 'h3', 'h4', 'h5', 'h6');
       }
 
+      function getChildrenRecursively(node, found){
+        if (node.name !== undefined && hTags.has(node.name)){
+          found.push(node);
+        }
+        if (node.children === undefined){
+          return;
+        }
+        for(var child of node.children){
+          getChildrenRecursively(child, found);
+        }
+      }
+
       function checkPastedContentForHeadings(ev) {
         var pastedContent = ev.data.dataValue,
           pastedContentAsHtml = CKEDITOR.htmlParser.fragment.fromHtml(pastedContent),
@@ -135,8 +148,14 @@
           writer = new CKEDITOR.htmlParser.basicWriter(),
           i, element, id, originalHeading;
 
+        var foundNodes = [];
         for (i = 0; i < pastedElements.length; i++) {
           element = pastedElements[i];
+          getChildrenRecursively(element, foundNodes);
+        }
+
+        for (i = 0; i < foundNodes.length; i++) {
+          element = foundNodes[i];
           if (element.type === CKEDITOR.NODE_ELEMENT) {
             id = element.attributes.id;
             originalHeading = checkForDuplicateId(id);


### PR DESCRIPTION
Promote https://github.com/PolicyStat/ckeditor-plugin-autoid-headings/pull/42 changes into `ckeditor-dev` repo

Part of https://trello.com/c/uJMj6fBd/344-autoid-headings-the-paste-duplicate-heading-id-detection-does-not-correctly-handle-headings-that-are-not-root-level
